### PR TITLE
fix: GitHub Actions リリース作成エラーを修正

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -65,13 +65,10 @@ jobs:
         
     - name: Create GitHub Release
       if: startsWith(github.ref, 'refs/tags/')
-      uses: actions/create-release@v1
-      id: create_release
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: softprops/action-gh-release@v2
       with:
         tag_name: ${{ github.ref_name }}
-        release_name: Release ${{ github.ref_name }}
+        name: Release ${{ github.ref_name }}
         body: |
           ## リリース内容
           - Android APKファイルを生成（野良APK配布用）
@@ -84,17 +81,10 @@ jobs:
           ## 注意事項
           - Google Play外のアプリのため、セキュリティ警告が表示されます
           - 自動更新されないため、新バージョンは手動でインストールしてください
+        files: |
+          build/app/outputs/flutter-apk/app-release.apk
         draft: false
         prerelease: false
-        
-    - name: Upload APK to Release
-      if: startsWith(github.ref, 'refs/tags/')
-      uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: build/app/outputs/flutter-apk/app-release.apk
-        asset_name: interval-timer-${{ github.ref_name }}.apk
-        asset_content_type: application/vnd.android.package-archive
         


### PR DESCRIPTION
## 問題
v1.0.0タグ作成時にGitHub Actionsでリリース作成が失敗しました。

```
Error: Resource not accessible by integration
```

## 原因
- `actions/create-release@v1` と `actions/upload-release-asset@v1` が古い
- 現在のGitHubトークン権限で動作しない

## 修正内容
- `softprops/action-gh-release@v2` に更新（より安全で信頼性の高いアクション）
- リリース作成とファイルアップロードを統合
- 最新のGitHub Actions標準に準拠

## テスト予定
このPRがマージされたら、新しいタグ（v1.0.1）でリリース機能をテストします。

🤖 Generated with [Claude Code](https://claude.ai/code)