### PR TITLE
fix: GitHub Actions でリリース作成権限を追加

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- GitHub Actions ワークフローに `contents: write` 権限を追加
- タグプッシュ時のGitHub Release自動作成エラーを修正

## Test plan
- [x] ワークフローファイルの権限設定を追加
- [ ] タグプッシュでリリース作成が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)