### PR TITLE
docs: Windows・Linux向けビルド情報をドキュメントに追加

### DIFF
--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -1,0 +1,113 @@
+name: Linux Release Build
+
+on:
+  push:
+    branches: [ main ]
+    tags:
+      - 'v*'
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install Linux dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev
+
+    - name: Setup Flutter
+      uses: subosito/flutter-action@v2
+      with:
+        flutter-version: '3.24.0'
+        channel: 'stable'
+
+    - name: Install dependencies
+      run: flutter pub get
+
+    - name: Run tests
+      run: flutter test
+
+    - name: Run static analysis
+      run: flutter analyze
+
+    - name: Extract version from tag
+      if: startsWith(github.ref, 'refs/tags/')
+      id: get_version
+      run: |
+        VERSION=${GITHUB_REF#refs/tags/v}
+        BUILD_NUMBER=${GITHUB_RUN_NUMBER}
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "build_number=$BUILD_NUMBER" >> $GITHUB_OUTPUT
+        echo "Version: $VERSION, Build: $BUILD_NUMBER"
+
+    - name: Build Linux (with tag version)
+      if: startsWith(github.ref, 'refs/tags/')
+      run: flutter build linux --release --build-name=${{ steps.get_version.outputs.version }} --build-number=${{ steps.get_version.outputs.build_number }}
+
+    - name: Build Linux (default version)
+      if: "!startsWith(github.ref, 'refs/tags/')"
+      run: flutter build linux --release
+
+    - name: Create archive
+      run: |
+        VERSION="${{ startsWith(github.ref, 'refs/tags/') && steps.get_version.outputs.version || 'dev' }}"
+        cd build/linux/x64/release/bundle
+        tar -czf ../../../../../interval-timer-linux-$VERSION.tar.gz *
+
+    - name: Upload Linux artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: linux-release
+        path: interval-timer-linux-*.tar.gz
+        retention-days: 30
+
+    - name: Create GitHub Release
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: ${{ github.ref_name }}
+        name: Release ${{ github.ref_name }}
+        body: |
+          ## リリース内容
+          - Linux実行ファイル（64ビット版）
+
+          ## インストール方法
+          1. 下記のtar.gzファイルをダウンロード
+          2. 適当なフォルダに解凍：
+             ```bash
+             tar -xzf interval-timer-linux-*.tar.gz
+             ```
+          3. 実行権限を付与（必要に応じて）：
+             ```bash
+             chmod +x interval_timer
+             ```
+          4. 実行：
+             ```bash
+             ./interval_timer
+             ```
+
+          ## システム要件
+          - Ubuntu 20.04以降、またはそれに相当するLinuxディストリビューション（64ビット）
+          - GTK 3.0以降
+
+          ## 注意事項
+          - ディストリビューションによっては追加の依存パッケージが必要な場合があります
+          - 依存関係が不足している場合は、以下をインストールしてください：
+            ```bash
+            sudo apt-get install libgtk-3-0 libblkid1 liblzma5
+            ```
+        files: |
+          interval-timer-linux-*.tar.gz
+        draft: false
+        prerelease: false
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -1,0 +1,95 @@
+name: Windows Release Build
+
+on:
+  push:
+    branches: [ main ]
+    tags:
+      - 'v*'
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Setup Flutter
+      uses: subosito/flutter-action@v2
+      with:
+        flutter-version: '3.24.0'
+        channel: 'stable'
+
+    - name: Install dependencies
+      run: flutter pub get
+
+    - name: Run tests
+      run: flutter test
+
+    - name: Run static analysis
+      run: flutter analyze
+
+    - name: Extract version from tag
+      if: startsWith(github.ref, 'refs/tags/')
+      id: get_version
+      shell: bash
+      run: |
+        VERSION=${GITHUB_REF#refs/tags/v}
+        BUILD_NUMBER=${GITHUB_RUN_NUMBER}
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "build_number=$BUILD_NUMBER" >> $GITHUB_OUTPUT
+        echo "Version: $VERSION, Build: $BUILD_NUMBER"
+
+    - name: Build Windows (with tag version)
+      if: startsWith(github.ref, 'refs/tags/')
+      run: flutter build windows --release --build-name=${{ steps.get_version.outputs.version }} --build-number=${{ steps.get_version.outputs.build_number }}
+
+    - name: Build Windows (default version)
+      if: "!startsWith(github.ref, 'refs/tags/')"
+      run: flutter build windows --release
+
+    - name: Create archive
+      shell: pwsh
+      run: |
+        $version = if ("${{ github.ref }}" -like "refs/tags/*") { "${{ steps.get_version.outputs.version }}" } else { "dev" }
+        Compress-Archive -Path build\windows\x64\runner\Release\* -DestinationPath interval-timer-windows-$version.zip
+
+    - name: Upload Windows artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: windows-release
+        path: interval-timer-windows-*.zip
+        retention-days: 30
+
+    - name: Create GitHub Release
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: ${{ github.ref_name }}
+        name: Release ${{ github.ref_name }}
+        body: |
+          ## リリース内容
+          - Windows実行ファイル（64ビット版）
+
+          ## インストール方法
+          1. 下記のZIPファイルをダウンロード
+          2. 適当なフォルダに解凍
+          3. `interval_timer.exe` を実行
+
+          ## システム要件
+          - Windows 10以降（64ビット）
+
+          ## 注意事項
+          - 初回実行時にWindows Defenderの警告が表示される場合があります
+          - 「詳細情報」→「実行」で起動できます
+        files: |
+          interval-timer-windows-*.zip
+        draft: false
+        prerelease: false
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_

--- a/.gitignore
+++ b/.gitignore
@@ -164,7 +164,3 @@ key.properties
 # Exceptions to above rules
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
 !/dev/ci/**/Gemfile.lock
-
-# Workflow files (add via GitHub Web UI due to permissions)
-.github/workflows/windows-release.yml
-.github/workflows/linux-release.yml

--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,7 @@ key.properties
 # Exceptions to above rules
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
 !/dev/ci/**/Gemfile.lock
+
+# Workflow files (add via GitHub Web UI due to permissions)
+.github/workflows/windows-release.yml
+.github/workflows/linux-release.yml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,8 @@ Widgetテストはアプリ初期化と基本UI要素を検証。タイマーロ
 
 **GitHub Actions**:
 - `.github/workflows/android-release.yml`によるAndroid APK自動ビルド
+- `.github/workflows/windows-release.yml`によるWindows実行ファイル自動ビルド
+- `.github/workflows/linux-release.yml`によるLinux実行ファイル自動ビルド
 - mainブランチpush時：開発用ビルド（Actionsタブにアーティファクト保存）
 - タグpush時：リリース用ビルド（GitHub Releaseページに自動作成）
 
@@ -131,10 +133,11 @@ Widgetテストはアプリ初期化と基本UI要素を検証。タイマーロ
 - ビルド番号：GitHub Actions実行番号を自動使用
 
 **リリース配布**:
-- 野良APK形式での配布に最適化
+- **Android**: 野良APK形式での配布（`interval-timer-android-*.apk`）
+- **Windows**: ZIP形式での配布（`interval-timer-windows-*.zip`、64ビット版）
+- **Linux**: tar.gz形式での配布（`interval-timer-linux-*.tar.gz`、64ビット版）
 - タグ作成で自動リリース：`git tag v1.0.0 && git push origin v1.0.0`
-- APKファイル名：`interval-timer-v1.0.0.apk`（タグと完全同期）
-- インストール方法と注意事項を含む日本語リリースノート自動生成
+- 各プラットフォーム向けのインストール方法と注意事項を含む日本語リリースノート自動生成
 
 ### 言語設定
 このプロジェクトは日本語UIで構築されており、すべてのユーザー向けテキストは日本語で記述されています。新機能やUIコンポーネントを追加する際は日本語を使用してください。

--- a/README.md
+++ b/README.md
@@ -74,24 +74,76 @@ flutter build ios
 
 # Web
 flutter build web
+
+# Windows
+flutter build windows
+
+# Linux
+flutter build linux
+
+# macOS
+flutter build macos
 ```
 
 ## リリースとダウンロード
 
-### APKダウンロード（野良アプリ配布）
-このアプリは野良APKとして配布されており、以下からダウンロードできます：
+このアプリは複数のプラットフォーム向けにビルドされたバイナリとして配布されています。
 
 **GitHub Releases**: [https://github.com/L7G45FRF/interval_timer/releases](https://github.com/L7G45FRF/interval_timer/releases)
 
-### インストール方法
-1. **APKファイルをダウンロード**: 最新リリースからAPKファイルを取得
+### Android版（野良APKダウンロード）
+
+#### インストール方法
+1. **APKファイルをダウンロード**: 最新リリースから`interval-timer-android-*.apk`を取得
 2. **セキュリティ設定を変更**: Android端末で「設定」→「セキュリティ」→「提供元不明のアプリ」を許可
 3. **APKをインストール**: ダウンロードしたAPKファイルをタップしてインストール
 
-### 注意事項
+#### 注意事項
 - **セキュリティ警告**: Google Play外のアプリのため、インストール時に警告が表示されます
 - **自動更新なし**: 新バージョンは手動でダウンロード・インストールが必要です
 - **自己責任**: 野良APKのインストールは自己責任で行ってください
+
+### Windows版
+
+#### インストール方法
+1. **ZIPファイルをダウンロード**: 最新リリースから`interval-timer-windows-*.zip`を取得
+2. **解凍**: 適当なフォルダに解凍
+3. **実行**: `interval_timer.exe`を起動
+
+#### システム要件
+- Windows 10以降（64ビット）
+
+#### 注意事項
+- 初回実行時にWindows Defenderの警告が表示される場合があります
+- 「詳細情報」→「実行」で起動できます
+
+### Linux版
+
+#### インストール方法
+1. **tar.gzファイルをダウンロード**: 最新リリースから`interval-timer-linux-*.tar.gz`を取得
+2. **解凍**:
+   ```bash
+   tar -xzf interval-timer-linux-*.tar.gz
+   ```
+3. **実行権限を付与**（必要に応じて）:
+   ```bash
+   chmod +x interval_timer
+   ```
+4. **実行**:
+   ```bash
+   ./interval_timer
+   ```
+
+#### システム要件
+- Ubuntu 20.04以降、またはそれに相当するLinuxディストリビューション（64ビット）
+- GTK 3.0以降
+
+#### 注意事項
+- ディストリビューションによっては追加の依存パッケージが必要な場合があります
+- 依存関係が不足している場合は、以下をインストールしてください：
+  ```bash
+  sudo apt-get install libgtk-3-0 libblkid1 liblzma5
+  ```
 
 ### リリース管理
 **開発者向け**: 新しいリリースを作成するには：
@@ -100,7 +152,7 @@ flutter build web
 git tag v1.0.0
 git push origin v1.0.0
 ```
-これにより、GitHub Actionsが自動的にAPKをビルドし、Releaseページに公開します。
+これにより、GitHub Actionsが自動的にAndroid、Windows、Linux向けのビルドを実行し、Releaseページに公開します。
 
 ### アプリアイコンの更新
 アプリアイコンを変更する場合：


### PR DESCRIPTION
CI/CDセクションとリリース配布セクションを更新し、
Windows・Linux向けの自動ビルド・リリースに関する情報を追加。

変更内容：
- CLAUDE.mdのCI/CDセクションを更新
  - Windows・Linux向けワークフローの説明を追加
  - 各プラットフォームの配布形式を明記
- README.mdのリリースセクションを拡充
  - Windows版のインストール方法とシステム要件を追加
  - Linux版のインストール方法と依存関係情報を追加
  - マルチプラットフォーム対応の説明を追記
  - ビルドコマンドにWindows・Linux・macOSを追加

注意: ワークフローファイル（windows-release.yml、linux-release.yml）は GitHub App権限の制約により、別途追加が必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)